### PR TITLE
Fix typo

### DIFF
--- a/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
+++ b/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
@@ -14,8 +14,8 @@ public abstract class TestDataCreator<ITEM> {
 
     protected final int numberOfItems;
 
-    protected TestDataCreator(int numberIfItems) {
-        this.numberOfItems = numberIfItems;
+    protected TestDataCreator(int numberOfItems) {
+        this.numberOfItems = numberOfItems;
     }
 
     public void commit() {


### PR DESCRIPTION
This typo is present in projects Finstral Composer, Aichner, EMVA and Boilerplate API and was inherited with the generated IDE implementation of the abstract class super constructor call.