### PR TITLE
Remove `@CheckReturnValue` from terminal operations

### DIFF
--- a/src/main/java/it/aboutbits/springboot/testing/testdata/base/AllTestDataReader.java
+++ b/src/main/java/it/aboutbits/springboot/testing/testdata/base/AllTestDataReader.java
@@ -25,7 +25,6 @@ public abstract class AllTestDataReader<ITEM> {
 
     @SafeVarargs
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public final List<ITEM> returnSorted(Comparator<ITEM>... comparators) {
         if (comparators.length == 0) {
             throw new IllegalArgumentException("At least one comparator must be provided");
@@ -41,7 +40,6 @@ public abstract class AllTestDataReader<ITEM> {
 
     @SafeVarargs
     @SuppressWarnings({"unchecked", "unused"})
-    @CheckReturnValue
     public final <U extends Comparable<? super U>> List<ITEM> returnSorted(Function<ITEM, ? extends Comparable<?>>... comparators) {
         if (comparators.length == 0) {
             throw new IllegalArgumentException("At least one comparator must be provided");
@@ -56,7 +54,6 @@ public abstract class AllTestDataReader<ITEM> {
     }
 
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <U extends Comparable<? super U>> AllAndFiltered<ITEM> returnFiltered(Predicate<ITEM> predicate) {
         var all = this.returnAll();
         return new AllAndFiltered<>(
@@ -74,7 +71,10 @@ public abstract class AllTestDataReader<ITEM> {
 
     protected abstract List<ITEM> fetch();
 
-    public record AllAndFiltered<T>(List<T> all, List<T> filtered, List<T> other) {
-
+    public record AllAndFiltered<T>(
+            List<T> all,
+            List<T> filtered,
+            List<T> other
+    ) {
     }
 }

--- a/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
+++ b/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
@@ -29,20 +29,17 @@ public abstract class TestDataCreator<ITEM> {
     }
 
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public ITEM returnFirst() {
         return create().getFirst();
     }
 
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public List<ITEM> returnAll() {
         return create();
     }
 
     @SafeVarargs
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public final List<ITEM> returnSorted(Comparator<ITEM>... comparators) {
         if (comparators.length == 0) {
             throw new IllegalArgumentException("At least one comparator must be provided");
@@ -58,7 +55,6 @@ public abstract class TestDataCreator<ITEM> {
 
     @SafeVarargs
     @SuppressWarnings({"unchecked", "unused"})
-    @CheckReturnValue
     public final <U extends Comparable<? super U>> List<ITEM> returnSorted(Function<ITEM, ? extends Comparable<?>>... comparators) {
         if (comparators.length == 0) {
             throw new IllegalArgumentException("At least one comparator must be provided");
@@ -73,7 +69,6 @@ public abstract class TestDataCreator<ITEM> {
     }
 
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public Set<ITEM> returnSet() {
         return new HashSet<>(create());
     }

--- a/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
+++ b/src/main/java/it/aboutbits/springboot/testing/testdata/base/TestDataCreator.java
@@ -1,6 +1,5 @@
 package it.aboutbits.springboot.testing.testdata.base;
 
-import com.google.errorprone.annotations.CheckReturnValue;
 import it.aboutbits.springboot.testing.testdata.FakerExtended;
 import org.jspecify.annotations.NullMarked;
 

--- a/src/main/java/it/aboutbits/springboot/testing/web/request/Request.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/request/Request.java
@@ -127,7 +127,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <T> ItemResponse<T> returnItem(Class<T> clazz) {
         var res = _execute();
 
@@ -146,7 +145,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <T, M extends Meta> ItemResponseWithMeta<T, M> returnItem(
             Class<T> clazz,
             Class<M> metaClass
@@ -168,7 +166,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <T> ListResponse<T> returnList(Class<T> clazz) {
         var res = _execute();
 
@@ -187,7 +184,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <T> PagedResponse<T> returnPage(Class<T> clazz) {
         var res = _execute();
 
@@ -206,7 +202,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public <T> T returnCustom(Class<T> clazz) {
         var res = _execute();
 
@@ -222,7 +217,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
 
     @SneakyThrows(UnsupportedEncodingException.class)
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public ErrorResponse returnError() {
         var res = _execute();
 
@@ -237,7 +231,6 @@ public abstract class Request<R extends AbstractMockHttpServletRequestBuilder<R>
     }
 
     @SuppressWarnings("unused")
-    @CheckReturnValue
     public ResultActions returnRaw() {
         return _execute();
     }


### PR DESCRIPTION
PR #35 accidentally also added the `@CheckReturnValue` for terminal operations, where we would get false positives in projects.