### PR TITLE
Add response body matchers

### DIFF
--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -1,6 +1,7 @@
 package it.aboutbits.springboot.testing.web.response;
 
 import com.jayway.jsonpath.JsonPath;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.test.web.servlet.ResultMatcher;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -15,8 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 
+@NullMarked
 public final class ResponseBodyMatchers {
-    private static final JsonMapper jsonMapper = new JsonMapper();
+    private static final JsonMapper JSON_MAPPER = new JsonMapper();
     private final String jsonPath;
 
     private String[] fieldNamesToIgnore = new String[0];
@@ -50,7 +52,7 @@ public final class ResponseBodyMatchers {
             try {
                 var json = mvcResult.getResponse().getContentAsString();
                 var extractedValue = JsonPath.read(json, jsonPath);
-                T actualObject = jsonMapper.readValue(jsonMapper.writeValueAsString(extractedValue), targetClass);
+                T actualObject = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(extractedValue), targetClass);
 
                 var ignoredFields = new ArrayList<>(Arrays.asList(fieldNamesToIgnore));
                 ignoredFields.addAll(Arrays.asList(optionalFieldNamesToIgnore));

--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -29,6 +29,14 @@ public final class ResponseBodyMatchers {
         this.jsonPath = jsonPath;
     }
 
+    public static ResponseBodyMatchers responseBody() {
+        return new ResponseBodyMatchers("$");
+    }
+
+    public static ResponseBodyMatchers responseBodyAt(String expression) {
+        return new ResponseBodyMatchers(expression);
+    }
+
     public ResponseBodyMatchers ignoringOptionalFields(String... optionalFieldNamesToIgnore) {
         this.optionalFieldNamesToIgnore = optionalFieldNamesToIgnore;
         return this;
@@ -39,7 +47,7 @@ public final class ResponseBodyMatchers {
         return this;
     }
 
-    public ResponseBodyMatchers ignoringAudition() {
+    public ResponseBodyMatchers ignoringAuditFields() {
         this.ignoreAudition = true;
         return this;
     }
@@ -52,7 +60,7 @@ public final class ResponseBodyMatchers {
             try {
                 var json = mvcResult.getResponse().getContentAsString();
                 var extractedValue = JsonPath.read(json, jsonPath);
-                T actualObject = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(extractedValue), targetClass);
+                T actualObject = JSON_MAPPER.convertValue(extractedValue, targetClass);
 
                 var ignoredFields = new ArrayList<>(Arrays.asList(fieldNamesToIgnore));
                 ignoredFields.addAll(Arrays.asList(optionalFieldNamesToIgnore));
@@ -86,13 +94,5 @@ public final class ResponseBodyMatchers {
 
     private static int compareTemporalByDelta(LocalDateTime a, LocalDateTime b) {
         return Math.abs(ChronoUnit.NANOS.between(a, b)) < 1000 ? 0 : a.compareTo(b);
-    }
-
-    public static ResponseBodyMatchers responseBody() {
-        return new ResponseBodyMatchers("$");
-    }
-
-    public static ResponseBodyMatchers responseBodyAt(String expression) {
-        return new ResponseBodyMatchers(expression);
     }
 }

--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -1,0 +1,95 @@
+package it.aboutbits.springboot.testing.web.response;
+
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.test.web.servlet.ResultMatcher;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.fail;
+
+public final class ResponseBodyMatchers {
+    public static JsonMapper jsonMapper = new JsonMapper();
+    private final String jsonPath;
+    private String[] fieldNamesToIgnore = new String[0];
+    private String[] optionalFieldNamesToIgnore = new String[0];
+    private boolean ignoreAudition = false;
+
+    private ResponseBodyMatchers(String jsonPath) {
+        this.jsonPath = jsonPath;
+    }
+
+    public ResponseBodyMatchers ignoringOptionalFields(String... optionalFieldNamesToIgnore) {
+        this.optionalFieldNamesToIgnore = optionalFieldNamesToIgnore;
+        return this;
+    }
+
+    public ResponseBodyMatchers ignoringFields(String... fieldNamesToIgnore) {
+        this.fieldNamesToIgnore = fieldNamesToIgnore;
+        return this;
+    }
+
+    public ResponseBodyMatchers ignoringAudition() {
+        this.ignoreAudition = true;
+        return this;
+    }
+
+    public <T> ResultMatcher containsObjectAsJson(
+            Object expectedObject,
+            Class<T> targetClass
+    ) {
+        return mvcResult -> {
+            try {
+                var json = mvcResult.getResponse().getContentAsString();
+                var extractedValue = JsonPath.read(json, jsonPath);
+                T actualObject = jsonMapper.readValue(jsonMapper.writeValueAsString(extractedValue), targetClass);
+
+                var ignoredFields = new ArrayList<>(Arrays.asList(fieldNamesToIgnore));
+                ignoredFields.addAll(Arrays.asList(optionalFieldNamesToIgnore));
+                if (ignoreAudition) {
+                    ignoredFields.addAll(Arrays.asList("createdAt", "createdBy", "updatedAt", "updatedBy"));
+                }
+
+                assertThat(actualObject)
+                        .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
+                        .usingComparatorForType(ResponseBodyMatchers::compareTemporalByDelta, OffsetDateTime.class)
+                        .usingComparatorForType(ResponseBodyMatchers::compareTemporalByDelta, LocalDateTime.class)
+                        .usingRecursiveComparison()
+                        .ignoringFields(ignoredFields.toArray(new String[0]))
+                        .isEqualTo(expectedObject);
+
+                for (var requiredFieldName : fieldNamesToIgnore) {
+                    assertThatCode(
+                            () -> JsonPath.read(json, jsonPath + "." + requiredFieldName)
+                    ).doesNotThrowAnyException();
+                }
+            } catch (Exception e) {
+                fail("Unable to extract result set. Maybe the path does not contain an object of that type?", e);
+            }
+        };
+    }
+
+    // Not every machine has 9 digits precision, so we need to compare with a delta
+    private static int compareTemporalByDelta(OffsetDateTime a, OffsetDateTime b) {
+        return Math.abs(ChronoUnit.NANOS.between(a, b)) < 1000 ? 0 : a.compareTo(b);
+    }
+
+    private static int compareTemporalByDelta(LocalDateTime a, LocalDateTime b) {
+        return Math.abs(ChronoUnit.NANOS.between(a, b)) < 1000 ? 0 : a.compareTo(b);
+    }
+
+    public static ResponseBodyMatchers responseBody() {
+        return new ResponseBodyMatchers("$");
+    }
+
+    public static ResponseBodyMatchers responseBodyAt(String expression) {
+        return new ResponseBodyMatchers(expression);
+    }
+}

--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 
 public final class ResponseBodyMatchers {
-    private final static JsonMapper jsonMapper = new JsonMapper();
+    private static final JsonMapper jsonMapper = new JsonMapper();
     private final String jsonPath;
 
     private String[] fieldNamesToIgnore = new String[0];

--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -23,7 +23,7 @@ public final class ResponseBodyMatchers {
 
     private String[] fieldNamesToIgnore = new String[0];
     private String[] optionalFieldNamesToIgnore = new String[0];
-    private boolean ignoreAudition = false;
+    private boolean ignoreAuditFields = false;
 
     private ResponseBodyMatchers(String jsonPath) {
         this.jsonPath = jsonPath;
@@ -48,7 +48,7 @@ public final class ResponseBodyMatchers {
     }
 
     public ResponseBodyMatchers ignoringAuditFields() {
-        this.ignoreAudition = true;
+        this.ignoreAuditFields = true;
         return this;
     }
 
@@ -64,7 +64,7 @@ public final class ResponseBodyMatchers {
 
                 var ignoredFields = new ArrayList<>(Arrays.asList(fieldNamesToIgnore));
                 ignoredFields.addAll(Arrays.asList(optionalFieldNamesToIgnore));
-                if (ignoreAudition) {
+                if (ignoreAuditFields) {
                     ignoredFields.addAll(Arrays.asList("createdAt", "createdBy", "updatedAt", "updatedBy"));
                 }
 

--- a/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
+++ b/src/main/java/it/aboutbits/springboot/testing/web/response/ResponseBodyMatchers.java
@@ -16,8 +16,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 
 public final class ResponseBodyMatchers {
-    public static JsonMapper jsonMapper = new JsonMapper();
+    private final static JsonMapper jsonMapper = new JsonMapper();
     private final String jsonPath;
+
     private String[] fieldNamesToIgnore = new String[0];
     private String[] optionalFieldNamesToIgnore = new String[0];
     private boolean ignoreAudition = false;


### PR DESCRIPTION
I know that we return the response object and test against that directly with normal assert methods in newer projects, but in older ones we use this body matcher instead. I found a bug in EMVA and instead of fixing it also in Aichner, it would be better to move it to the lib and deprecate both copy/paste implementations in each project